### PR TITLE
Allow the report processor to run on PE

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@
 class datadog(
   $api_key = 'your key',
   $puppet_run_reports = false,
-  $puppetmaster_user = 'puppet'
+  $puppetmaster_user = $settings::user,
 ) inherits datadog::params {
 
   include datadog::params


### PR DESCRIPTION
The PE puppetserver runs as `pe-puppet`, not `puppet`.

The $settings::user variable resolves to the user that the Puppet Master node is configured to run as. This patch assumes that you are either enforcing as the agent on the Puppet Master node, or that if you're enforcing on a compile master that it will be the same as the Master of Masters.
